### PR TITLE
add spring security and keycloak

### DIFF
--- a/config-service/pom.xml
+++ b/config-service/pom.xml
@@ -17,6 +17,14 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-config-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-
 </project>

--- a/config-service/src/main/java/com/stas_kozh/config/SecurityConfig.java
+++ b/config-service/src/main/java/com/stas_kozh/config/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.stas_kozh.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(CsrfConfigurer::disable)
+                .cors(CorsConfigurer::disable)
+                .sessionManagement(config -> config
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(config -> config
+                        .anyRequest().authenticated())
+                .httpBasic(Customizer.withDefaults())
+                .build();
+    }
+}

--- a/config-service/src/main/resources/application.yml
+++ b/config-service/src/main/resources/application.yml
@@ -8,5 +8,11 @@ spring:
           uri: ${GIT_URI}
           clone-on-start: true
           default-label: master
+  security:
+    user:
+      name: ${USERNAME}
+      password: ${PASSWORD}
+      roles:
+        - CONFIG
 server:
   port: ${PORT}

--- a/cv-service/.env.sample
+++ b/cv-service/.env.sample
@@ -4,5 +4,6 @@ DB_NAME=cv
 DB_PORT=5436
 DB_URL=jdbc:postgresql://localhost:5436/cv
 EUREKA_URL=http://localhost:8761/eureka
-CONFIG_URI=http://localhost:8888
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092, localhost:9094
+ISSUER_URI=http://localhost:9080/realms/cv-application
+CONFIG_URI=http://config:1234@localhost:8888

--- a/employee-service/.env.sample
+++ b/employee-service/.env.sample
@@ -4,4 +4,5 @@ DB_NAME=employees
 DB_PORT=5435
 DB_URL=jdbc:postgresql://localhost:5435/employees
 EUREKA_URL=http://localhost:8761/eureka
-CONFIG_URI=http://localhost:8888
+KEYCLOAK_ISSUER_URI=http://localhost:9080/realms/cv-application
+CONFIG_URI=http://config:1234@localhost:8888

--- a/employee-service/pom.xml
+++ b/employee-service/pom.xml
@@ -108,6 +108,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/employee-service/src/main/java/com/stas_kozh/config/SecurityConfig.java
+++ b/employee-service/src/main/java/com/stas_kozh/config/SecurityConfig.java
@@ -1,0 +1,81 @@
+package com.stas_kozh.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.refresh.ConfigDataContextRefresher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerAuthenticationManagerResolver;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Value("#{'${spring.security.oauth2.resourceserver.jwt.issuer-uri}'.split(',')}")
+    private List<String> issuerUris;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, ConfigDataContextRefresher configDataContextRefresher) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .sessionManagement(config -> config
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(config -> config
+                        .requestMatchers("/employee/*/cv").hasRole("USER")
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer(this::customizeResourceServer)
+                .build();
+    }
+
+    private JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        JwtGrantedAuthoritiesConverter authoritiesConverter = new JwtGrantedAuthoritiesConverter();
+
+        converter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            var authorities = authoritiesConverter.convert(jwt);
+            var roles = (List<String>) jwt.getClaimAsMap("realm_access").get("roles");
+
+            return Stream.concat(authorities.stream(),
+                            roles.stream()
+                                    .map(role -> "ROLE_" + role)
+                                    .map(SimpleGrantedAuthority::new)
+                                    .map(GrantedAuthority.class::cast))
+                    .toList();
+        });
+
+        return converter;
+    }
+
+    private void customizeResourceServer(OAuth2ResourceServerConfigurer<HttpSecurity> customizer) {
+        Map<String, AuthenticationManager> authenticationManagers = new HashMap<>();
+
+        JwtIssuerAuthenticationManagerResolver authenticationManagerResolver =
+                new JwtIssuerAuthenticationManagerResolver(authenticationManagers::get);
+
+        issuerUris.forEach(issuer -> {
+            JwtAuthenticationProvider authenticationProvider = new JwtAuthenticationProvider(
+                    JwtDecoders.fromOidcIssuerLocation(issuer));
+            authenticationProvider.setJwtAuthenticationConverter(jwtAuthenticationConverter());
+            authenticationManagers.put(issuer, authenticationProvider::authenticate);
+        });
+
+        customizer.authenticationManagerResolver(authenticationManagerResolver);
+    }
+}

--- a/employee-service/src/main/resources/application.yml
+++ b/employee-service/src/main/resources/application.yml
@@ -4,6 +4,11 @@ server:
 spring:
   application:
     name: EMPLOYEE-SERVICE
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI}
   config:
     import: 'optional:configserver:'
   cloud:

--- a/employee-service/src/test/java/com/stas_kozh/CdcTest.java
+++ b/employee-service/src/test/java/com/stas_kozh/CdcTest.java
@@ -3,6 +3,7 @@ package com.stas_kozh;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stas_kozh.config.DisableSecurityConfig;
 import com.stas_kozh.model.Outbox;
 import io.debezium.testing.testcontainers.ConnectorConfiguration;
 import io.debezium.testing.testcontainers.DebeziumContainer;
@@ -24,6 +25,7 @@ import org.springframework.kafka.listener.MessageListener;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
@@ -45,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @DirtiesContext
 @ActiveProfiles("test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ContextConfiguration(classes = {DisableSecurityConfig.class})
 @SpringBootTest()
 public class CdcTest {
     public static final String EMPLOYEES_DBZ_CONNECTOR = "employees-dbz-connector";

--- a/employee-service/src/test/java/com/stas_kozh/config/DisableSecurityConfig.java
+++ b/employee-service/src/test/java/com/stas_kozh/config/DisableSecurityConfig.java
@@ -1,0 +1,25 @@
+package com.stas_kozh.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.context.refresh.ConfigDataContextRefresher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class DisableSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, ConfigDataContextRefresher configDataContextRefresher) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .sessionManagement(config -> config
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(config -> config
+                        .anyRequest().permitAll())
+                .build();
+    }
+}

--- a/employee-service/src/test/resources/application-test.yml
+++ b/employee-service/src/test/resources/application-test.yml
@@ -1,6 +1,11 @@
 spring:
   application:
     name: EMPLOYEE-SERVICE
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:9080/realms/cv-application
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yml
   config:

--- a/gateway/.env.sample
+++ b/gateway/.env.sample
@@ -1,2 +1,4 @@
 GATEWAY_PORT=8080
 EUREKA_URL=http://localhost:8761/eureka
+KEYCLOAK_ISSUER_URI=http://localhost:9080/realms/cv-application
+SPRING_ISSUER_URI=http://localhost:9000

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -34,6 +34,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/gateway/src/main/java/com/stas_kozh/gateway/config/SecurityConfig.java
+++ b/gateway/src/main/java/com/stas_kozh/gateway/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.stas_kozh.gateway.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerReactiveAuthenticationManagerResolver;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+import java.util.List;
+
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+    @Value("#{'${spring.security.oauth2.resourceserver.jwt.issuer-uri}'.split(',')}")
+    private List<String> issuerUris;
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(auth -> auth
+                        .anyExchange().authenticated()
+                )
+                .oauth2ResourceServer(this::customizeResourceServer)
+                .build();
+    }
+
+    private void customizeResourceServer(ServerHttpSecurity.OAuth2ResourceServerSpec customizer) {
+        customizer.authenticationManagerResolver(JwtIssuerReactiveAuthenticationManagerResolver
+                .fromTrustedIssuers(issuerUris)
+        );
+    }
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   application:
     name: GATEWAY
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI}
   cloud:
     gateway:
       routes:

--- a/pom.xml
+++ b/pom.xml
@@ -16,15 +16,14 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
-        <module>service-registry</module>
-        <module>employee-service</module>
-<!--        <module>cv-service</module>-->
-        <module>gateway</module>
-<!--        <module>identity-service</module>-->
-<!--        <module>client</module>-->
         <module>config-service</module>
+        <module>service-registry</module>
+        <module>gateway</module>
         <module>core</module>
-<!--        <module>streaming-service</module>-->
+        <module>employee-service</module>
+        <module>cv-service</module>
+        <module>streaming-service</module>
+
     </modules>
 
     <properties>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing security configurations across multiple services by integrating OAuth2 resource server capabilities, adding issuer URIs, and implementing security filters to manage authentication and authorization.

### Detailed summary
- Added `KEYCLOAK_ISSUER_URI` and `SPRING_ISSUER_URI` in `.env.sample` files.
- Configured security settings in `application.yml` files for `gateway`, `config-service`, and `employee-service`.
- Introduced `spring-boot-starter-oauth2-resource-server` dependency in `pom.xml` files.
- Created `SecurityConfig` classes in `config` packages for managing security configurations.
- Implemented JWT authentication handling in `SecurityConfig` for both `gateway` and `employee-service`.
- Added `DisableSecurityConfig` for testing purposes in `employee-service`.
- Updated test configurations to include security context management in `CdcTest`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->